### PR TITLE
rewrite messages to group and subcommands

### DIFF
--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -58,6 +58,29 @@ class Messages(commands.Cog):
         self.messages = MessageLoader('assets/')
         self.message_names = ', '.join(list(self.messages.load_names()))
 
+    async def move_action(self, ctx, count: int, target: TextChannel, copy: bool):
+        messages = []
+        zero_width_space = u'\u200B'
+        async for message in ctx.message.channel.history(limit=count):
+            if message.embeds:
+                messages.extend(message.embeds)
+            else:
+                embed = Embed(
+                    description=f'{zero_width_space}{message.content}')
+                embed.set_author(name=message.author.name,
+                                    icon_url=message.author.avatar_url)
+                embed.timestamp = message.created_at
+                messages.append(embed)
+
+            if not copy:
+                await message.delete()
+
+        await target.send(f'Moved from {ctx.message.channel.mention}:')
+
+        for embed in reversed(messages):
+            await target.send(embed=embed)
+
+
     @commands.command()
     @commands.has_permissions(manage_messages=True)
     async def purge(self, ctx, limit: int, target: User = None):
@@ -76,48 +99,35 @@ class Messages(commands.Cog):
             await sleep(3)
             await message.delete()
 
-    @commands.command()
+    @commands.group(name="move", invoke_without_command= True, case_insensitive=True)
+    async def move_group(self, ctx):
+        if ctx.invoked_subcommand is None:
+            message = await ctx.send(f"Invalid subcommand passed.  Use {self.bot.command_prefix}help move for available subcommands.")
+            await sleep(3)
+            await message.delete()
+
+    @move_group.command(name="last", aliases=["count", "previous"])
     @commands.has_permissions(manage_messages=True)
-    async def move(self, ctx, count: int, target: TextChannel, copy: bool = False):
+    async def last_subcommand(self, ctx, count: int, target: TextChannel, copy: bool = False):
         """Move/copy specified amount of messages to target channel"""
+        await ctx.message.delete()
         async with target.typing():
-            await ctx.message.delete()
-            messages = []
-            zero_width_space = u'\u200B'
-            async for message in ctx.message.channel.history(limit=count):
-                if message.embeds:
-                    messages.extend(message.embeds)
-                else:
-                    embed = Embed(
-                        description=f'{zero_width_space}{message.content}')
-                    embed.set_author(name=message.author.name,
-                                     icon_url=message.author.avatar_url)
-                    embed.timestamp = message.created_at
-                    messages.append(embed)
+            await Messages.move_action(self, ctx, count, target, copy)
 
-                if not copy:
-                    await message.delete()
-
-            await target.send(f'Moved from {ctx.message.channel.mention}:')
-
-            for embed in reversed(messages):
-                await target.send(embed=embed)
-
-    @move.error
-    async def move_error(self, ctx, error):
+    @last_subcommand.error
+    async def last_subcommand_error(self, ctx, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.message.delete()
             temp = await ctx.send("Error! Missing one or more of the following arguments: count, target")
             await sleep(3)
             await temp.delete()
 
-    @commands.command()
+    @move_group.command(name="from", aliases=["link"])
     @commands.has_permissions(manage_messages=True)
-    async def linkmove(self, ctx, messageID: int, target: TextChannel, copy: bool = False):
+    async def from_subcommand(self, ctx, messageID: int, target: TextChannel, copy: bool = False):
         """Move/copy all messages up to (and including) a message ID"""
         await ctx.message.delete()
         count = 0
-        found = 0
         async for message in ctx.message.channel.history(limit=100):
             count += 1
             if message.id == messageID:
@@ -126,36 +136,82 @@ class Messages(commands.Cog):
 
         async with target.typing():
             if found == 1:
-                messages = []
-                zero_width_space = u'\u200B'
-                async for message in ctx.message.channel.history(limit=count):
-                    if message.embeds:
-                        messages.extend(message.embeds)
-                    else:
-                        embed = Embed(
-                            description=f'{zero_width_space}{message.content}')
-                        embed.set_author(name=message.author.name,
-                                         icon_url=message.author.avatar_url)
-                        embed.timestamp = message.created_at
-                        messages.append(embed)
-
-                    if not copy:
-                        await message.delete()
-
-                await target.send(f'Moved from {ctx.message.channel.mention}:')
-
-                for embed in reversed(messages):
-                    await target.send(embed=embed)
+                await Messages.move_action(self, ctx, (count + 20), target, copy)
             else:
                 temp = await ctx.send(f"Error! Unable to find message with ID: {messageID}")
                 await sleep(3)
                 await temp.delete()
 
-    @linkmove.error
-    async def move_error(self, ctx, error):
+    @from_subcommand.error
+    async def from_subcommand_error(self, ctx, error):
         if isinstance(error, commands.MissingRequiredArgument):
             await ctx.message.delete()
             temp = await ctx.send("Error! Missing one or more of the following arguments: messageID, target")
+            await sleep(3)
+            await temp.delete()
+
+    @move_group.command(name="range", aliases=["between"])
+    @commands.has_permissions(manage_messages=True)
+    async def range_subcommand(self, ctx, firstMessageID: int, secondMessageID: int, target: TextChannel, copy: bool = False):
+        """Move/copy all messages up to (and including) a message ID"""
+        await ctx.message.delete()
+        firstMessageFound: int = 0
+        secondMessageFound: int = 0
+        async for message in ctx.message.channel.history(limit=100):
+            if message.id == firstMessageID:
+                firstMessageFound = 1
+            if message.id == secondMessageID:
+                secondMessageFound = 1
+            if firstMessageFound == secondMessageFound == 1:
+                break
+
+        async with target.typing():
+            messages = []
+            zero_width_space = u'\u200B'
+            firstMessageMoved: int = 0
+            secondMessageMoved: int = 0
+            if firstMessageFound == secondMessageFound == 1:
+                async for message in ctx.message.channel.history(limit=100):
+                    if message.id == firstMessageID:
+                        firstMessageMoved = 1
+                    if message.id == secondMessageID:
+                        secondMessageMoved = 1
+                    if firstMessageMoved == 1 or secondMessageMoved == 1:
+                        if message.embeds:
+                            messages.extend(message.embeds)
+                        else:
+                            embed = Embed(
+                                description=f'{zero_width_space}{message.content}')
+                            embed.set_author(name=message.author.name,
+                                                icon_url=message.author.avatar_url)
+                            embed.timestamp = message.created_at
+                            messages.append(embed)
+
+                        if not copy:
+                            await message.delete()
+                        if firstMessageMoved == secondMessageMoved == 1:
+                            break
+
+                await target.send(f'Moved from {ctx.message.channel.mention}:')
+
+                for embed in reversed(messages):
+                    await target.send(embed=embed)
+                    
+            else:
+                if firstMessageFound == 1:
+                    temp = await ctx.send(f"Error! Unable to find message with ID: {messageID2}")
+                elif secondMessageFound == 1:
+                    temp = await ctx.send(f"Error! Unable to find message with ID: {messageID1}")
+                else:
+                    temp = await ctx.send(f"Error! Unable to find either message with IDs: {messageID1}, {messageID2}")
+                await sleep(3)
+                await temp.delete()
+
+    @range_subcommand.error
+    async def range_subcommand_error(self, ctx, error):
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.message.delete()
+            temp = await ctx.send("Error! Missing one or more of the following arguments: messageID, secondMessageID, target")
             await sleep(3)
             await temp.delete()
 


### PR DESCRIPTION
This is a rewrite of the Messages move commands.  It add them all to a Move group which uses more meaningfully named subcommands and aliases.
It also adds a range/between option for move select blocks of messages.